### PR TITLE
Create SKPreference to allow easy integration with driver station preferences

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ java {
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"
 
+repositories {
+    mavenCentral()
+}
+
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project DeployUtils.
 deploy {

--- a/src/main/java/frc/robot/commands/IntakeTransferCommand.java
+++ b/src/main/java/frc/robot/commands/IntakeTransferCommand.java
@@ -2,6 +2,8 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
+import frc.robot.preferences.Pref;
+import frc.robot.preferences.SKPreferences;
 import frc.robot.subsystems.SK24Intake;
 import frc.robot.subsystems.SK24Launcher;
 

--- a/src/main/java/frc/robot/preferences/BooleanPref.java
+++ b/src/main/java/frc/robot/preferences/BooleanPref.java
@@ -1,0 +1,25 @@
+package frc.robot.preferences;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class BooleanPref extends Pref<Boolean> {
+
+  BooleanPref(String key, Boolean defaultValue, boolean reset) {
+    super(key, defaultValue, reset);
+  }
+
+  @Override
+  void write(String key, Boolean value) {
+    Preferences.setBoolean(key, value);
+  }
+
+  @Override
+  void init(String key, Boolean value) {
+    Preferences.initBoolean(key, value);
+  }
+
+  @Override
+  Boolean read(String key) {
+    return Preferences.getBoolean(key, defaultValue);
+  }
+}

--- a/src/main/java/frc/robot/preferences/DoublePref.java
+++ b/src/main/java/frc/robot/preferences/DoublePref.java
@@ -1,0 +1,25 @@
+package frc.robot.preferences;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+final class DoublePref extends Pref<Double> {
+
+  DoublePref(String key, Double defaultValue, boolean reset) {
+    super(key, defaultValue, reset);
+  }
+
+  @Override
+  void write(final String key, final Double value) {
+    Preferences.setDouble(key, value);
+  }
+
+  @Override
+  Double read(final String key) {
+    return Preferences.getDouble(key, defaultValue);
+  }
+
+  @Override
+  void init(String key, Double value) {
+    Preferences.initDouble(key, value);
+  }
+}

--- a/src/main/java/frc/robot/preferences/FloatPref.java
+++ b/src/main/java/frc/robot/preferences/FloatPref.java
@@ -1,0 +1,25 @@
+package frc.robot.preferences;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+final class FloatPref extends Pref<Float> {
+
+  FloatPref(String key, Float defaultValue, boolean reset) {
+    super(key, defaultValue, reset);
+  }
+
+  @Override
+  void write(final String key, final Float value) {
+    Preferences.setFloat(key, value);
+  }
+
+  @Override
+  Float read(final String key) {
+    return Preferences.getFloat(key, defaultValue);
+  }
+
+  @Override
+  void init(String key, Float value) {
+    Preferences.initFloat(key, value);
+  }
+}

--- a/src/main/java/frc/robot/preferences/IntPref.java
+++ b/src/main/java/frc/robot/preferences/IntPref.java
@@ -1,0 +1,25 @@
+package frc.robot.preferences;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+final class IntPref extends Pref<Integer> {
+
+  IntPref(String key, Integer defaultValue, boolean reset) {
+    super(key, defaultValue, reset);
+  }
+
+  @Override
+  void write(final String key, final Integer value) {
+    Preferences.setInt(key, value);
+  }
+
+  @Override
+  Integer read(final String key) {
+    return Preferences.getInt(key, defaultValue);
+  }
+
+  @Override
+  void init(String key, Integer value) {
+    Preferences.initInt(key, value);
+  }
+}

--- a/src/main/java/frc/robot/preferences/LongPref.java
+++ b/src/main/java/frc/robot/preferences/LongPref.java
@@ -1,0 +1,25 @@
+package frc.robot.preferences;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+final class LongPref extends Pref<Long> {
+
+  LongPref(String key, Long defaultValue, boolean reset) {
+    super(key, defaultValue, reset);
+  }
+
+  @Override
+  void write(final String key, final Long value) {
+    Preferences.setLong(key, value);
+  }
+
+  @Override
+  Long read(final String key) {
+    return Preferences.getLong(key, defaultValue);
+  }
+
+  @Override
+  void init(String key, Long value) {
+    Preferences.initLong(key, value);
+  }
+}

--- a/src/main/java/frc/robot/preferences/Pref.java
+++ b/src/main/java/frc/robot/preferences/Pref.java
@@ -1,0 +1,97 @@
+package frc.robot.preferences;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * A handle to a driver station preference.
+ * 
+ * Provides methods to fetch the latest value and then read it.
+ */
+public abstract class Pref<T> {
+
+  // Probably won't have more than one listener, so lowering default capacity from 10 to 2.
+  private List<Consumer<T>> listeners = new ArrayList<>(2);
+  private final String key;
+  public final T defaultValue;
+  private T value;
+
+  Pref(final String key, final T defaultValue, final boolean reset) {
+    this.key = key;
+    this.defaultValue = defaultValue;
+
+    // Initialize to defaultValue if it doesn't already exist.
+    if (reset) {
+      write(key, defaultValue);
+    } else {
+      init(key, defaultValue);
+    }
+
+    // Read back the saved preference data.
+    this.value = read(key);
+  }
+
+  /**
+   * Gets the most recently polled value. You must call {@link #poll()} to update
+   * the value.
+   * 
+   * This method provides no thread safety. If a value is updated on driver
+   * station at the same time that it is
+   * updated here, the value may not be updated until the next call to
+   * {@link #poll()}.
+   * 
+   * @return The latest value polled from driver station.
+   */
+  public T get() {
+    return this.value;
+  }
+
+  /**
+   * Fetches the latest value from driver station.
+   */
+  void poll() {
+    final var previous = this.value;
+    this.value = read(key);
+
+    // Use '.equals' since some types (e.g. string) can't be compared with '!=' or '=='.
+    if (!this.value.equals(previous)) {
+      // Send the updated info to subscribers.
+      listeners.forEach((listener) -> listener.accept(this.value));
+    }
+  }
+
+  public Pref<T> onChange(Consumer<T> consumer) {
+    this.listeners.add(consumer);
+    return this;
+  }
+
+  void clearListeners() {
+    this.listeners.clear();
+  }
+
+  abstract void write(final String key, final T value);
+
+  abstract void init(final String key, final T value);
+
+  abstract T read(final String key);
+
+  public static Pref<? extends Object> create(final String key, final Object defaultValue, final boolean reset) {
+    if (defaultValue instanceof String) {
+      return new StringPref(key, (String) defaultValue, reset);
+    } else if (defaultValue instanceof Integer) {
+      return new IntPref(key, (Integer) defaultValue, reset);
+    } else if (defaultValue instanceof Long) {
+      return new LongPref(key, (Long) defaultValue, reset);
+    } else if (defaultValue instanceof Float) {
+      return new FloatPref(key, (Float) defaultValue, reset);
+    } else if (defaultValue instanceof Double) {
+      return new DoublePref(key, (Double) defaultValue, reset);
+    } else if (defaultValue instanceof Boolean) {
+      return new BooleanPref(key, (Boolean) defaultValue, reset);
+    } else {
+      throw new RuntimeException(
+          String.format("Unsupported pref type '%s' for key '%s'.", defaultValue.getClass().getCanonicalName(), key));
+    }
+  }
+}

--- a/src/main/java/frc/robot/preferences/SKPreferences.java
+++ b/src/main/java/frc/robot/preferences/SKPreferences.java
@@ -1,0 +1,195 @@
+package frc.robot.preferences;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A wrapper around {@link edu.wpi.first.wpilibj.Preferences} which simplifies
+ * their usage.
+ * 
+ * Example usage:
+ * 
+ * <pre>
+ * Pref<Float> kP = SKPreferences.attach(Constants.Launcher.KpKey, Constants.Launcher.defaultKp)
+ *     .onChange(pid::setP);
+ * Pref<Float> kI = SKPreferences.attach(Constants.Launcher.KiKey, Constants.Launcher.defaultKi)
+ *     .onChange(pid::setI);
+ * Pref<Float> kD = SKPreferences.attach(Constants.Launcher.KdKey, Constants.Launcher.defaultKd)
+ *     .onChange(pid::setD);
+ * 
+ * // elsewhere...
+ * launcher.setSpeed(pid.calculate(currentSpeed, setpoint));
+ * </pre>
+ * 
+ * In the above example, the PID would adjust its behavior whenever new values
+ * were specified in the driver station for
+ * any 'Constants.Launcher.KKey' value.
+ * 
+ * 
+ * You may also do something like so:
+ * 
+ * <pre>
+ * Pref<Float> setpoint = SKPreferences.attach(Constants.Launcher.setpointKey, Constants.Launcher.defaultSetpoint)
+ * 
+ * // elsewhere...
+ * launcher.setSpeed(pid.calculate(currentSpeed, setpoint.get()));
+ * </pre>
+ * 
+ * This allows you to read from the preference value directly if you'd rather
+ * not use the reactive 'onChange' approach.
+ */
+public class SKPreferences {
+
+  private static final long UPDATE_INTERVAL_MS = 2000L;
+  private long lastUpdate = 0L;
+
+  /**
+   * Whether or not to reset values from the code side whenever a new pref is
+   * created.
+   */
+  private boolean resetEnabled = true;
+
+  private Map<String, Pref<? extends Object>> handles = new HashMap<>();
+
+  // Consumers of SKPreferences should not create instances directly.
+  private SKPreferences() {
+  }
+
+  /** @see {@link SKPreferences#initializeFromCode(boolean)} */
+  void enableReset(boolean reset) {
+    this.resetEnabled = reset;
+  }
+
+  /**
+   * Used to implement {@link #refreshIfNeeded()} and {@link #forceRefresh()}.
+   */
+  private void poll(final boolean force) {
+    final long now = System.currentTimeMillis();
+    if (!force && (now - lastUpdate) < UPDATE_INTERVAL_MS)
+      return;
+
+    for (final String key : handles.keySet()) {
+      handles.get(key).poll();
+    }
+
+    lastUpdate = now;
+  }
+
+  /** @see {@link #attach(String, Object)} */
+  @SuppressWarnings("unchecked")
+  private synchronized <T> Pref<T> attachPref(final String key, final T defaultValue) {
+    final var proposedHandle = (Pref<T>) Pref.create(key, defaultValue, this.resetEnabled);
+    if (handles.containsKey(key)) {
+      // Make sure the provided handle doesn't conflict with the existing one.
+      final var currentHandle = (Pref<T>) handles.get(key);
+      if (proposedHandle.getClass() != currentHandle.getClass()) {
+        // Trying to overwrite an existing handle with a different handle type.
+        throw new RuntimeException(
+            String.format(
+                "Already registered '%s' for key '%s', cannot register different handle type '%s'.",
+                currentHandle.getClass().getCanonicalName(),
+                key,
+                proposedHandle.getClass().getCanonicalName()));
+      } else if (currentHandle.defaultValue != proposedHandle.defaultValue) {
+        System.err.println(
+            String.format(
+                "Ignoring default value %s for key %s, a different default '%s' was set elsewhere.",
+                String.valueOf(defaultValue),
+                key,
+                String.valueOf(currentHandle.defaultValue)));
+      }
+    } else {
+      handles.put(key, proposedHandle);
+    }
+
+    return (Pref<T>) handles.get(key);
+  }
+
+  private synchronized void detachAll() {
+    handles.values().forEach((pref) -> pref.clearListeners());
+    handles.clear();
+  }
+
+  // Public API is static for simplicity of use.
+  // Note for students: Typically, we would use the instance() method outside of
+  // this class, as opposed to using
+  // static methods which wrap calls to instance(), e.g.
+  // `RxPreferences.instance().attach(...)`.
+
+  private static SKPreferences singleton;
+
+  // Utility to make sure the internal singleton is initialized correctly.
+  private static synchronized SKPreferences instance() {
+    return singleton == null ? (singleton = new SKPreferences()) : singleton;
+  }
+
+  /**
+   * Decides whether or not preferences treat the pre-existing preferences or the
+   * robot as the source of truth.
+   * 
+   * This method should only be called ONCE before any calls to
+   * {@link #attach(String, Object)}.
+   * 
+   * @param useCode Set to true if the robot should always be initialized with
+   *                code-side values. Set to false if you
+   *                would like to persist preferences across robot power-cycles or
+   *                roborio reboots. The default behavior is to
+   *                always reset from code (e.g. useCode=true).
+   */
+  public static void initializeFromCode(boolean useCode) {
+    instance().enableReset(useCode);
+  }
+
+  /**
+   * This method will read all of the latest preference data from network tables,
+   * and is designed to be called by a
+   * command that runs periodically as long as the robot is enabled.
+   * 
+   * It will not trigger a full refresh each invocation, but only if a certain
+   * amount of time has elapsed since the
+   * last refresh. This is intended to minimize the impact of reading many values
+   * from network tables all at once.
+   */
+  public static void refreshIfNeeded() {
+    instance().poll(false);
+  }
+
+  /**
+   * Immediately reads the latest values from the driver station.
+   */
+  public static void forceRefresh() {
+    instance().poll(true);
+  }
+
+  /**
+   * Creates a preference which will be periodically updated by the SKPreferences
+   * object.
+   * 
+   * @param <T>          The value-type you want to observe. Supports: String,
+   *                     Int, Long, Float, Double, Boolean
+   * @param key          The key to observe. Multiple calls will return the same
+   *                     {@link Pref}, but only the first one will set
+   *                     the default value for the preference.
+   * @param defaultValue The value to initialize the preference if it has not
+   *                     already been configured.
+   * @return A {@link Pref} which will periodically update based on preferences
+   *         set on driver station.
+   * 
+   * @throws RuntimeException If trying to register handles of different types to
+   *                          the same key.
+   */
+  public static <T> Pref<T> attach(String key, T defaultValue) {
+    return instance().attachPref(key, defaultValue);
+  }
+
+  /**
+   * Stops all previously attached preferences from receiving updates.
+   * 
+   * Only newly attached preferences will receive updates after this is called.
+   * 
+   * This is mainly intended for unit testing purposes.
+   */
+  public static void disableAllPrefs() {
+    instance().detachAll();
+  }
+}

--- a/src/main/java/frc/robot/preferences/StringPref.java
+++ b/src/main/java/frc/robot/preferences/StringPref.java
@@ -1,0 +1,25 @@
+package frc.robot.preferences;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+final class StringPref extends Pref<String> {
+
+  StringPref(String key, String defaultValue, boolean reset) {
+    super(key, defaultValue, reset);
+  }
+
+  @Override
+  void write(final String key, final String value) {
+    Preferences.setString(key, value);
+  }
+
+  @Override
+  String read(final String key) {
+    return Preferences.getString(key, defaultValue);
+  }
+
+  @Override
+  void init(String key, String value) {
+    Preferences.initString(key, value);
+  }
+}

--- a/src/test/java/frc/robot/TestUtil.java
+++ b/src/test/java/frc/robot/TestUtil.java
@@ -1,0 +1,10 @@
+package frc.robot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestUtil {
+
+  public static <T> void assertEqualsWithMessage(T expected, T result) {
+    assertEquals(expected, result, String.format("%s != %s", String.valueOf(result), String.valueOf(expected)));
+  }
+}

--- a/src/test/java/frc/robot/preferences/TestPref.java
+++ b/src/test/java/frc/robot/preferences/TestPref.java
@@ -1,0 +1,229 @@
+package frc.robot.preferences;
+
+import java.math.BigInteger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.Preferences;
+
+import static frc.robot.TestUtil.assertEqualsWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestPref {
+
+  NetworkTableInstance testNetworkTableInstance;
+
+  @BeforeEach
+  void setUp() {
+    testNetworkTableInstance = NetworkTableInstance.create();
+    Preferences.setNetworkTableInstance(testNetworkTableInstance);
+  }
+
+  @AfterEach
+  void reset() {
+    Preferences.removeAll();
+    testNetworkTableInstance.close();
+  }
+
+  @Test
+  void testThrowsForInvalidType() {
+
+    assertThrows(RuntimeException.class, () -> {
+      // Preferences doesn't support BigInteger, so this is invalid.
+      Pref.create("key", new BigInteger("0"), true);
+    });
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  void testResetsFromCodeDefaultWhenResetIsTrue(String key, Object defaultValue, Object nonDefaultValue) {
+    // Setup
+    // Initialize to non-default values.
+    initializePrefs(false);
+
+    // Execute
+    Pref<?> pref = Pref.create(key, defaultValue, true);
+
+    // Assert
+    assertEqualsWithMessage(defaultValue, pref.get());
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  void testResetsFromCodeDefaultWhenResetIsFalseButPriorValueIsMissing(String key, Object defaultValue,
+      Object nonDefaultValue) {
+    // Execute
+    Pref<?> pref = Pref.create(key, defaultValue, false);
+
+    // Assert
+    assertEqualsWithMessage(defaultValue, pref.get());
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  void testRetainsPreconfiguredValueWhenResetIsFalse(String key, Object defaultValue, Object nonDefaultValue) {
+    // Setup
+    // Initialize to non-default values.
+    initializePrefs(false);
+
+    // Execute
+    Pref<?> pref = Pref.create(key, defaultValue, false);
+
+    // Assert
+    assertEqualsWithMessage(nonDefaultValue, pref.get());
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  void testUpdateNotReceivedWithoutPoll(String key, Object defaultValue, Object nonDefaultValue) {
+    // Setup
+    var capture = new ValueCapture();
+    Pref<?> pref = Pref.create(key, defaultValue, false).onChange(capture::capture);
+
+    // Execute
+    updatePref(key, nonDefaultValue);
+
+    // Assert
+    assertEqualsWithMessage(defaultValue, pref.get());
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  void testUpdatingPrefBroadcastsNewValueToAllListeners(String key, Object defaultValue, Object nonDefaultValue) {
+    // Setup
+    var captureA = new ValueCapture();
+    var captureB = new ValueCapture();
+    Pref<?> pref = Pref.create(key, defaultValue, false)
+        .onChange(captureA::capture)
+        .onChange(captureB::capture);
+
+    // Phase 1 -- Make sure updates are received by all listeners.
+    // Execute 1
+    updatePref(key, nonDefaultValue);
+    pref.poll();
+
+    // Assert 1
+    assertEqualsWithMessage(nonDefaultValue, pref.get());
+    assertEqualsWithMessage(nonDefaultValue, captureA.captured);
+    assertEqualsWithMessage(nonDefaultValue, captureB.captured);
+
+    // Phase 2 -- Make further updates are still received by all listeners.
+    // Execute 2
+    updatePref(key, defaultValue);
+    pref.poll();
+
+    // Assert 2
+    assertEqualsWithMessage(defaultValue, pref.get());
+    assertEqualsWithMessage(defaultValue, captureA.captured);
+    assertEqualsWithMessage(defaultValue, captureB.captured);
+  }
+
+  @ParameterizedTest
+  @MethodSource("testArgs")
+  void testDuplicatePollsDoNotCauseOnChangeToTrigger(String key, Object defaultValue, Object nonDefaultValue) {
+    // Setup
+    var capture = new ValueCapture();
+    Pref<?> pref = Pref.create(key, defaultValue, false)
+        .onChange(capture::capture);
+
+    // Execute
+    for (int i = 0; i < 5; i++) {
+      updatePref(key, nonDefaultValue);
+      pref.poll();
+    }
+
+    // Assert
+    assertEqualsWithMessage(nonDefaultValue, pref.get());
+    assertEqualsWithMessage(1, capture.count);
+  }
+
+  static Stream<Arguments> testArgs() {
+    return Stream.of(
+        Arguments.of(Keys.INT, Defaults.INT, NonDefaults.INT),
+        Arguments.of(Keys.LONG, Defaults.LONG, NonDefaults.LONG),
+        Arguments.of(Keys.FLOAT, Defaults.FLOAT, NonDefaults.FLOAT),
+        Arguments.of(Keys.DOUBLE, Defaults.DOUBLE, NonDefaults.DOUBLE),
+        Arguments.of(Keys.BOOLEAN, Defaults.BOOLEAN, NonDefaults.BOOLEAN),
+        Arguments.of(Keys.STRING, Defaults.STRING, NonDefaults.STRING));
+  }
+
+  private static void updatePref(String key, Object value) {
+    switch (key) {
+      case Keys.INT:
+        Preferences.setInt(key, (int) value);
+        break;
+      case Keys.LONG:
+        Preferences.setLong(key, (long) value);
+        break;
+      case Keys.FLOAT:
+        Preferences.setFloat(key, (float) value);
+        break;
+      case Keys.DOUBLE:
+        Preferences.setDouble(key, (double) value);
+        break;
+      case Keys.BOOLEAN:
+        Preferences.setBoolean(key, (boolean) value);
+        break;
+      case Keys.STRING:
+        Preferences.setString(key, (String) value);
+        break;
+      default:
+        throw new RuntimeException(String.format("Invalid preference value: %s", value));
+    }
+  }
+
+  private static void initializePrefs(boolean useDefault) {
+    testArgs().forEach((args) -> {
+      final String key = (String) args.get()[0];
+      final var defaultValue = args.get()[1];
+      final var nonDefaultValue = args.get()[2];
+      final var value = useDefault ? defaultValue : nonDefaultValue;
+      updatePref(key, value);
+    });
+  }
+
+  private static class Keys {
+    static final String INT = "int";
+    static final String LONG = "long";
+    static final String FLOAT = "float";
+    static final String DOUBLE = "double";
+    static final String BOOLEAN = "boolean";
+    static final String STRING = "string";
+  }
+
+  private static class Defaults {
+    static final int INT = 123;
+    static final long LONG = 123l;
+    static final float FLOAT = 123f;
+    static final double DOUBLE = 123.0;
+    static final boolean BOOLEAN = true;
+    static final String STRING = "default";
+  }
+
+  private static class NonDefaults {
+    static final int INT = -1;
+    static final long LONG = -1l;
+    static final float FLOAT = -1f;
+    static final double DOUBLE = -1.0;
+    static final boolean BOOLEAN = false;
+    static final String STRING = "non-default";
+  }
+
+  private static class ValueCapture {
+
+    private Object captured;
+    private int count = 0;
+
+    void capture(Object obj) {
+      this.captured = obj;
+      this.count += 1;
+    }
+  }
+}

--- a/src/test/java/frc/robot/preferences/TestSKPreferences.java
+++ b/src/test/java/frc/robot/preferences/TestSKPreferences.java
@@ -1,0 +1,78 @@
+package frc.robot.preferences;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.Preferences;
+
+import static frc.robot.TestUtil.assertEqualsWithMessage;
+
+public class TestSKPreferences {
+  private static final String TEST_KEY = "test";
+
+  NetworkTableInstance testNetworkTableInstance;
+
+  @BeforeEach
+  void setUp() {
+    testNetworkTableInstance = NetworkTableInstance.create();
+    Preferences.setNetworkTableInstance(testNetworkTableInstance);
+  }
+
+  @AfterEach
+  void tearDown() {
+    testNetworkTableInstance.close();
+    SKPreferences.disableAllPrefs();
+
+    // Reset to default behavior after each test.
+    SKPreferences.initializeFromCode(true);
+  }
+
+  @Test
+  void valueUpdatesWhenUpstreamValueChanges() {
+    // Setup
+    final var expected = 123.0;
+    Pref<Double> pref = SKPreferences.attach(TEST_KEY, 0.0);
+
+    // Execute
+    Preferences.setDouble(TEST_KEY, expected);
+    SKPreferences.refreshIfNeeded();
+
+    // Assert
+    final var result = pref.get();
+    assertEqualsWithMessage(expected, result);
+  }
+
+  @Test
+  void overwritesWithRobotCodeDefaultValueByDefault() {
+    // Setup
+    final var expected = 123.0;
+    final var unexpected = -1.0;
+    Preferences.initDouble(TEST_KEY, unexpected);
+
+    // Execute
+    SKPreferences.attach(TEST_KEY, expected);
+
+    // Assert
+    final var result = Preferences.getDouble(TEST_KEY, unexpected);
+    assertEqualsWithMessage(expected, result);
+  }
+
+  @Test
+  void overwritesWithPredefinedValueWhenNotInitializingFromCode() {
+    // Setup
+    final var expected = 123.0;
+    final var unexpected = -1.0;
+    Preferences.initDouble(TEST_KEY, expected);
+    SKPreferences.initializeFromCode(false);
+
+    // Execute
+    SKPreferences.attach(TEST_KEY, unexpected);
+
+    // Assert
+    final var result = Preferences.getDouble(TEST_KEY, unexpected);
+
+    assertEqualsWithMessage(expected, result);
+  }
+}


### PR DESCRIPTION
## Overview

WPILib offers a preferences class that allows for preferences to be set and persisted via driver station. These preferences are synced internally using network-tables between the robot and the driver station.

This makes it easy to deploy new values to the robot without rebuilding and redeploying code each time.

It is a bit awkward to use the preferences class directly, so I created a wrapper that makes it a bit easier to integrate.

By default, every time you start the robot, it will re-initialize the preferences in driver station to the values specified in code. This ensures that the code is our main source of truth for what our "good" defaults are, though if you'd like to persist configurations between restarts, there is a mechanism to support this behavior.

## Usage Examples

```
Pref<Boolean> useLimelight = SKPreference.attach("useLimelightKey", /* defaultValue */ true)

if (useLimelight.get()) {
    // do something with the limelight
} 
```

This will create a key in a table that is accessible through the driver stations that can be toggled by the driver called "useLimelightKey".

There is also a mechanism to use reactive/event-driven programming.

```
Pref<Float> kP = SKPreference.attach("pidPKey", /* defaultValue */ 0.01).onChange(pid::setP);
```

In this example, any time the driver sets a new value for "pidPKey", the pid on the robot will be updated to use the new value.


## Performance Considerations

- New values are only read once every 2 seconds. This is still faster than redeploying code, but makes the performance impact of this code minimal.
- Thread safety is not enabled for reading values. This means we might sometimes read a stale value, but the next time the value is polled from the driver station it should automatically fix itself. You should only every have one command that is triggering refreshes at a given time, because you are much more likely to have weird issues if you try running the refresh methods from different commands or threads simultaneously. Full thread safety is slow, which is why it was not added (in addition to making the code more complicated).
  - In summary, as long as you don't call refresh from different commands / threads, you should be okay.
